### PR TITLE
Update PatientMatcher, remove patientCompare overwrite on match

### DIFF
--- a/src/main/java/org/immregistries/mismo/match/PatientMatcher.java
+++ b/src/main/java/org/immregistries/mismo/match/PatientMatcher.java
@@ -19,7 +19,6 @@ public class PatientMatcher {
 
   public PatientMatchResult match(Patient patientA, Patient patientB) {
     PatientMatchResult patientMatchResult = new PatientMatchResult();
-    PatientCompare patientCompare = new PatientCompare();
     patientCompare.setPatientA(patientA);
     patientCompare.setPatientB(patientB);
     String result = patientCompare.getResult();


### PR DESCRIPTION
When calling the match method on the PatientMatcher, the patientCompare object gets overwritten with a new instance instead of using the preconfigured one. This PR removes the override.