### PR TITLE
Clear the matcher after a comparison

### DIFF
--- a/src/main/java/org/immregistries/mismo/match/PatientMatcher.java
+++ b/src/main/java/org/immregistries/mismo/match/PatientMatcher.java
@@ -31,6 +31,7 @@ public class PatientMatcher {
     }
     patientMatchResult.addMatchSignature(
         new MatchSignature(patientCompare.getSignature(), MatchSignatureType.PRIMARY));
+    patientCompare.clear();
     return patientMatchResult;
   }
 


### PR DESCRIPTION
The match result stays cached in the PatientCompare object which makes the subsequent match calls return the wrong result, this PR adds the "clear" call after processing a comparison which makes a comparison stateless.